### PR TITLE
Fix for potential cyclical reference creation in RGAs

### DIFF
--- a/ron-rdt/CHANGELOG.md
+++ b/ron-rdt/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 and this project adheres to
 [Compatible Versioning](https://github.com/staltz/comver).
 
+## [0.12.1] - 2026-03-16
+* Added some duplicate operation removal to `vertexListFromOps`
+* Changed `applyPatch` to prefer new operations over existing ones when
+  updating the `HashMap UUID VertexListItem`.
+
 ## [0.12] - 2022-03-11
 - Added `Editable` typeclass which generalizes RON.Data.RGA.edit
 

--- a/ron-rdt/lib/RON/Data/LWW.hs
+++ b/ron-rdt/lib/RON/Data/LWW.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- | LWW-per-field RDT
 module RON.Data.LWW (

--- a/ron-rdt/lib/RON/Data/ORSet/Experimental.hs
+++ b/ron-rdt/lib/RON/Data/ORSet/Experimental.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module RON.Data.ORSet.Experimental (
   ORSet,

--- a/ron-rdt/lib/RON/Data/RGA.hs
+++ b/ron-rdt/lib/RON/Data/RGA.hs
@@ -48,6 +48,7 @@ import qualified Data.HashMap.Strict as HashMap
 import           Data.Map.Strict ((!?))
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
+import           Data.List (nubBy)
 
 import           RON.Data.Internal (MonadObjectState,
                                     Editable (..),

--- a/ron-rdt/lib/RON/Data/RGA.hs
+++ b/ron-rdt/lib/RON/Data/RGA.hs
@@ -119,7 +119,7 @@ vertexListToOps v@VertexList {..} = go listHead listItems
        in itemValue : rest
 
 vertexListFromOps :: [Vertex] -> Maybe VertexList
-vertexListFromOps = foldr go mempty
+vertexListFromOps = foldr go mempty . nubBy (\Op{opId = opIdA} Op{opId = opIdB} -> opIdA == opIdB)
   where
     go v@Op{opId} vlist = Just VertexList{listHead = opId, listItems = vlist'}
       where
@@ -276,7 +276,7 @@ applyPatch parent patch targetItems = case parent of
           Nothing -> patch
           Just next -> VertexList next targetItems <> patch
     let item' = item {itemNext = Just next'}
-    pure $ HashMap.insert parent item' targetItems <> newItems
+    pure $ HashMap.insert parent item' newItems <> targetItems
 
 reapplyRemovalsToState :: (RgaRep, PatchSet) -> Maybe (RgaRep, PatchSet)
 reapplyRemovalsToState (RgaRep rstate, ps@PatchSet {..}) = do

--- a/ron-rdt/ron-rdt.cabal
+++ b/ron-rdt/ron-rdt.cabal
@@ -1,7 +1,7 @@
 cabal-version:  2.2
 
 name:           ron-rdt
-version:        0.10
+version:        0.12.1
 
 bug-reports:    https://github.com/ff-notes/ron/issues
 category:       Distributed Systems, Protocol, Database


### PR DESCRIPTION
# RON RGA `applyPatch` Bug

A bug in the [RON](https://github.com/ff-notes/ron) RGA (Replicated Growable Array) implementation where `HashMap.union` bias in `applyPatch` causes interleaved patch vertices to become orphaned.

## The Bug

In `RON.Data.RGA.applyPatch` (~line 298), the expression:

```haskell
pure $ HashMap.insert parent item' targetItems <> newItems
```

uses `HashMap.union` (via `<>`), which is **left-biased**. `targetItems` contains **stale** `itemNext` pointers that override the **correct** pointers from `newItems` (the merge result). This causes vertices that should interleave into the linked list to become orphaned and silently dropped.

**Fix** — swap operands so `newItems` takes precedence:

```haskell
pure $ HashMap.insert parent item' $ HashMap.union newItems targetItems
```

# `vertexListFromOps` creates cycles from duplicate `opId`s

**Location:** [`ron/ron-rdt/lib/RON/Data/RGA.hs:135-143`](ron/ron-rdt/lib/RON/Data/RGA.hs#L135-L143)

```haskell
vertexListFromOps :: [Vertex] -> Maybe VertexList
vertexListFromOps = foldr go mempty
  where
    go v@Op{opId} vlist = Just VertexList{listHead = opId, listItems = vlist'}
      where
        item itemNext = VertexListItem {itemValue = v, itemNext}
        vlist' = case vlist of
          Nothing -> HashMap.singleton opId (item Nothing)
          Just VertexList {listHead, listItems} ->
            HashMap.insert opId (item $ Just listHead) listItems
            -- ^^^^^^^^^^^^^^^^
            -- If opId already exists, HashMap.insert OVERWRITES the previous
            -- entry's next pointer, corrupting the linked-list structure
```

**Effect:** Duplicate `opId`s in the input `[Op]` list cause `HashMap.insert` to overwrite an existing vertex's `itemNext`, creating a cycle. This is the direct cause of the production crash.
